### PR TITLE
escape chars to prevent xss in responses and tracebacks

### DIFF
--- a/tcrudge/__init__.py
+++ b/tcrudge/__init__.py
@@ -6,4 +6,4 @@ Validates input using JSON-schema.
 Supports JSON and MessagePack responses.
 """
 
-__version__ = '0.9.6'
+__version__ = '0.9.7'

--- a/tcrudge/handlers.py
+++ b/tcrudge/handlers.py
@@ -43,6 +43,12 @@ class BaseHandler(web.RequestHandler):
         'application/x-msgpack': response_msgpack,
     }
 
+    def get_query_argument(self, name, default= object(), strip=True):
+        val = super().get_query_argument(name, default, strip)
+        if isinstance(val, str):
+            return xhtml_escape(val)
+        return val
+    
     def get_response(self, result=None, errors=None, **kwargs):
         """
         Method returns conventional formatted byte answer.
@@ -138,9 +144,10 @@ class BaseHandler(web.RequestHandler):
         errors = []
         for error in v.iter_errors(_data):
             # error is an instance of jsonschema.exceptions.ValidationError
+            err_msg = xhtml_escape(error.message)
             errors.append({'code': '',
                            'message': 'Validation failed',
-                           'detail': error.message})
+                           'detail': err_msg})
         if errors:
             # data does not pass validation
             raise HTTPError(400, body=self.get_response(errors=errors))


### PR DESCRIPTION
created two things:

1) a wrapper over the 'get_query_argument' tornado's method - to escape chars in strings
2) xhtm_escape over the error messages to prevent scripts loading through exception tracebacks

thanks